### PR TITLE
[CombatText] Fix to check for value range in GetRuneCooldown call

### DIFF
--- a/ShestakUI/Modules/Blizzard/CombatText.lua
+++ b/ShestakUI/Modules/Blizzard/CombatText.lua
@@ -326,7 +326,8 @@ local function OnEvent(_, event, subevent, powerType)
 		end
 	elseif event == "RUNE_POWER_UPDATE" then
 		local arg1 = subevent
-		if GetRuneCooldown(arg1) ~= 0 then return end
+		local validRuneType = arg1 and type(arg1) == "number" and arg1 >= 0 and arg1 <= 6
+		if not validRuneType or GetRuneCooldown(arg1) ~= 0 then return end
 		xCT3:AddMessage("+"..COMBAT_TEXT_RUNE_DEATH, 0.75, 0, 0)
 	elseif event == "UNIT_ENTERED_VEHICLE" or event == "UNIT_EXITING_VEHICLE" then
 		local arg1 = subevent


### PR DESCRIPTION
Two users on Discord reported an error here. https://discord.com/channels/476450334089412638/593461999569207296/1202774785247940739

![image](https://github.com/Wetxius/ShestakUI/assets/49285632/5550b6d8-14af-4af1-ac92-1db6f67e4975)
![image](https://github.com/Wetxius/ShestakUI/assets/49285632/201ab250-1447-4957-9bd8-06b866bf1cb8)
